### PR TITLE
Add a sigterm handler

### DIFF
--- a/lab/runnerctl.py
+++ b/lab/runnerctl.py
@@ -9,9 +9,12 @@ pytest runner control plugin
 """
 from builtins import object
 import string
+import signal
 import pytest
 
 
+def exit_gracefully(signum, frame):
+    raise pytest.exit('Interrupting from SIGTERM')
 
 
 class Halt(object):
@@ -26,6 +29,10 @@ class Halt(object):
 
 def pytest_namespace():
     return {'halt': Halt()}
+
+
+def pytest_configure(config):
+    signal.signal(signal.SIGTERM, exit_gracefully)
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/lab/runnerctl.py
+++ b/lab/runnerctl.py
@@ -8,14 +8,10 @@
 pytest runner control plugin
 """
 from builtins import object
-import pytest
 import string
+import pytest
 
 
-def pytest_runtest_makereport(item, call):
-    if 'setup_test' in item.keywords and call.excinfo:
-        if not call.excinfo.errisinstance(pytest.skip.Exception):
-            pytest.halt('A setup test has failed, aborting...')
 
 
 class Halt(object):
@@ -37,6 +33,12 @@ def pytest_runtest_protocol(item, nextitem):
     yield
     if pytest.halt.msg:
         item.session.shouldstop = pytest.halt.msg
+
+
+def pytest_runtest_makereport(item, call):
+    if 'setup_test' in item.keywords and call.excinfo:
+        if not call.excinfo.errisinstance(pytest.skip.Exception):
+            pytest.halt('A setup test has failed, aborting...')
 
 
 @pytest.fixture(scope='class')


### PR DESCRIPTION
Triggers `pytest.exit` on SIGTERM. Simple and straightforward. Raises `_pytest.runner.Exit` behind the scenes - which `KeyboardInterrupt` also gets transformed into.

If triggered twice, just like with Ctrl+C, the test run aborts immediately. If we decided we want to put a timer on it, lets do it when someone complains about that later.