### PR TITLE
Attempt to futurize ipaddress module

### DIFF
--- a/lab/futurize.py
+++ b/lab/futurize.py
@@ -8,11 +8,43 @@ import sys
 import pytest
 
 
+def monkey_patch_support_for_python2():
+    from future import standard_library
+    standard_library.install_aliases()
+
+    try:
+        # Monkey patch the backported ipaddress module with
+        # alternative versions that accept string addresses, in
+        # addition to unicode addresses, in python2 code.
+        #
+        # This keep compatibility simple. Slightly complicated by the
+        # fact that some of these classes inherit from each other.
+        import ipaddress
+
+        def python2_compat(cls, bases=()):
+            def __init__(self, address, *args, **kwargs):
+                if isinstance(address, basestring):
+                    address = address.decode('utf-8')
+                return cls.__init__(self, address, *args, **kwargs)
+
+            return type(cls.__name__, (cls,) + bases, {'__init__': __init__})
+
+        ipaddress.IPv4Network = python2_compat(ipaddress.IPv4Network)
+        ipaddress.IPv4Address = python2_compat(ipaddress.IPv4Address)
+        ipaddress.IPv4Interface = python2_compat(ipaddress.IPv4Interface,
+                                                 bases=(ipaddress.IPv4Address,))
+
+        ipaddress.IPv6Network = python2_compat(ipaddress.IPv6Network)
+        ipaddress.IPv6Address = python2_compat(ipaddress.IPv6Address)
+        ipaddress.IPv6Interface = python2_compat(ipaddress.IPv6Interface,
+                                                 bases=(ipaddress.IPv6Address,))
+    except ImportError:
+        pass
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_load_initial_conftests(early_config, parser, args):
     # Monkey patch imports for python2 before any conftests are loaded
     if sys.version_info[0] < 3:
-        from future import standard_library
-        standard_library.install_aliases()
-
+        monkey_patch_support_for_python2()
     yield

--- a/lab/network/__init__.py
+++ b/lab/network/__init__.py
@@ -64,7 +64,7 @@ def get_addr_version(addr):
     -------
     version : Int, the IP version (4 or 6)
     '''
-    return ipaddress.ip_address(addr.decode('utf-8')).version
+    return ipaddress.ip_address(addr).version
 
 
 def check_ipaddr(dst, version=4):
@@ -76,13 +76,13 @@ def check_ipaddr(dst, version=4):
     for res in socket.getaddrinfo(dst, 0, family, socket.SOCK_STREAM, 0,
                                   socket.AI_PASSIVE | socket.AI_CANONNAME):
         family, socktype, proto, canonname, sa = res
-        addr = ipaddress.ip_address(sa[0].decode('utf-8'))
-        return addr, canonname.decode('utf-8')
+        addr = ipaddress.ip_address(sa[0])
+        return addr, canonname
 
 
 def iter_addrs(data):
     for ipaddr in data['ipaddr']:
-        yield ipaddress.ip_interface(u'{}/{}'.format(*ipaddr))
+        yield ipaddress.ip_interface('{}/{}'.format(*ipaddr))
 
 
 def ip_ifaces(version=4):

--- a/lab/network/macvlan.py
+++ b/lab/network/macvlan.py
@@ -80,7 +80,7 @@ class MacVLan(object):
 
         ipaddrs = self.ipdb.interfaces[self.name].ipaddr
         for addr, prefix in ipaddrs:
-            addr = ipaddress.ip_address(addr.decode('utf-8'))
+            addr = ipaddress.ip_address(addr)
             if addr.is_link_local:
                 continue
             elif addr.version == 4:

--- a/unittests/test_networking.py
+++ b/unittests/test_networking.py
@@ -12,7 +12,7 @@ from lab import network
 @pytest.fixture
 def dhcp_network():
     """The default Docker network"""
-    return ipaddress.IPv4Network(u'172.17.0.0/16')
+    return ipaddress.IPv4Network('172.17.0.0/16')
 
 
 @pytest.fixture
@@ -83,9 +83,9 @@ def test_addr_version_detection(ip, expected):
 
 
 @pytest.mark.parametrize('ip, version, expected', [
-    ('127.0.0.1', 4, ipaddress.IPv4Address(u'127.0.0.1')),
-    ('::1', 6, ipaddress.IPv6Address(u'::1')),
-    ('localhost.localdomain', 4, ipaddress.IPv4Address(u'127.0.0.1'))
+    ('127.0.0.1', 4, ipaddress.IPv4Address('127.0.0.1')),
+    ('::1', 6, ipaddress.IPv6Address('::1')),
+    ('localhost.localdomain', 4, ipaddress.IPv4Address('127.0.0.1'))
 ])
 def test_check_ipaddr(ip, version, expected):
     assert network.check_ipaddr(ip, version=version) == (expected, ip)


### PR DESCRIPTION
Since we use the future module for python2 support, I figured its appropriate to change our ipaddress library usage to conform to what python3 expects and monkey patch the library so the python2 code continues to work.

Without this, test harness doesn't work under python3...