### PR TITLE
Add pnet (here, for now) and a new DHCP4 client

### DIFF
--- a/lab/futurize.py
+++ b/lab/futurize.py
@@ -22,7 +22,7 @@ def monkey_patch_support_for_python2():
 
     def python2_compat(cls, bases=()):
         def __init__(self, address, *args, **kwargs):
-            if isinstance(address, str):
+            if isinstance(address, str) and len(address) > 4:
                 address = address.decode('utf-8')
             return cls.__init__(self, address, *args, **kwargs)
 

--- a/lab/network/dhcp.py
+++ b/lab/network/dhcp.py
@@ -49,6 +49,7 @@ def generate_packet(src, data):
                   'len': len(data) + udphdr.min_size},
                  buf=ip4.payload)
 
+    ip4['csum'] = pnet.checksum(ip4.tobytes())
     udp['csum'] = pnet.ipv4_checksum(ip4, udp, data)
     udp.payload = data
     return packet

--- a/lab/network/dhcp.py
+++ b/lab/network/dhcp.py
@@ -7,27 +7,162 @@
 from builtins import object
 import time
 import select
+import socket
+import fcntl
+import struct
 import logging
 import threading
-from pyroute2 import dhcp
-from pyroute2.dhcp.dhcp4msg import dhcp4msg
-from pyroute2.dhcp.dhcp4socket import DHCP4Socket
+import ipaddress
+import errno
+import pnet
+from pnet import udphdr, ethhdr, ip4hdr, dhcp4
+from pnet.bpf import attach_filter
+from pnet.dhcp4 import DHCPPacket, DHCPMessage, DHCPOption, DHCPOpCode, bootp_filter
 
+
+SIOCGIFHWADDR = 0x8927
 
 logger = logging.getLogger(__name__)
 
-DHCP_PARAMS = [1, 3, 6, 12, 15, 28]
+
+def get_ifreq(sock, ifname):
+    ifreq = struct.pack('256s', ifname.encode('ascii')[:15])
+    return fcntl.ioctl(sock.fileno(), SIOCGIFHWADDR, ifreq)
 
 
-class DHCP(object):
+def generate_packet(src, data):
+    min_size = ethhdr.min_size + ip4hdr.min_size + udphdr.min_size
+    packet = bytearray(len(data) + min_size)
+
+    eth = ethhdr({'src': src,
+                  'dst': pnet.HWAddress(u'ff:ff:ff:ff:ff:ff'),
+                  'type': pnet.ETH_P_IP},
+                 buf=packet)
+
+    ip4 = ip4hdr({'dst': ipaddress.IPv4Address(u'255.255.255.255'),
+                  'proto': socket.IPPROTO_UDP,
+                  'len': len(data) + ip4hdr.min_size + udphdr.min_size},
+                 buf=eth.payload)
+
+    udp = udphdr({'sport': 68,
+                  'dport': 67,
+                  'len': len(data) + udphdr.min_size},
+                 buf=ip4.payload)
+
+    udp['csum'] = pnet.ipv4_checksum(ip4, udp, data)
+    udp.payload = data
+    return packet
+
+
+class DHCP4Socket(object):
+    def __init__(self, ifname):
+        self.ifname = ifname
+        self.poll = select.epoll()
+        self.sock = socket.socket(socket.AF_PACKET, socket.SOCK_RAW,
+                                  socket.htons(pnet.ETH_P_ALL))
+        self.poll.register(self.sock, select.POLLIN | select.POLLPRI |
+                           select.POLLHUP | select.POLLERR)
+        attach_filter(self.sock, bootp_filter())
+        self.sock.setblocking(0)
+        self.sock.bind((ifname, 3))
+
+        ifreq = get_ifreq(self.sock, ifname)
+        self.src = pnet.HWAddress(ifreq[18:24])
+
+    def send(self, packet, src=None, expect=None, interval=2, retry=3,
+             timeout=10):
+        src = src or self.src
+        msg = generate_packet(src, packet.tobytes())
+
+        if not expect:
+            self.sock.send(msg)
+            return
+
+        def recv_all():
+            while True:
+                try:
+                    payload, addr = self.sock.recvfrom(0x1000)
+                    eth = ethhdr.parse(payload)
+                    ip4 = ip4hdr.parse(eth.payload)
+                    udp = udphdr.parse(ip4.payload)
+                    reply = DHCPPacket.parse(udp.payload)
+                except socket.error as e:
+                    if e.errno != errno.EAGAIN:
+                        raise e
+                    return None
+                except pnet.ParseError:
+                    continue
+
+                if reply.xid != packet.xid:
+                    continue
+                elif reply.message_type != expect:
+                    raise RuntimeError('DHCP protocol error')
+                return reply
+
+        starttime = time.time()
+        for _ in range(retry - 1):
+            self.sock.send(msg)
+
+            loop_starttime = time.time()
+            waitfor = interval
+            while waitfor > 0:
+                for fd, _ in self.poll.poll(waitfor):
+                    assert fd == self.sock.fileno()
+                    reply = recv_all()
+                    if reply:
+                        return reply
+
+                waitfor -= time.time() - loop_starttime
+
+        waitfor = timeout - (time.time() - starttime)
+        if waitfor > 0:
+            self.sock.send(msg)
+
+            for fd, _ in self.poll.poll(waitfor):
+                assert fd == self.sock.fileno()
+                return recv_all()
+
+        raise RuntimeError('Failed to acquire dhcp lease')
+
+
+def build_options(message_type, chaddr, requested_ip=None,
+                  hostname=None, vendor=None):
+    if not hostname:
+        hostname = socket.gethostname()
+    if not vendor:
+        vendor = dhcp4.get_vendor_info()
+
+    common = [
+        (DHCPOption.DHCPMessageType, [message_type]),
+        (DHCPOption.ClientIdentifier, dhcp4.get_client_id(chaddr)),
+        (DHCPOption.MaximumDHCPMessageSize, [0x05, 0xc0]),
+        (DHCPOption.VendorClassIdentifier, vendor.encode('ascii')),
+        (DHCPOption.HostName, hostname.encode('ascii')),
+        (DHCPOption.ParameterRequestList, [
+            DHCPOption.SubnetMask,
+            DHCPOption.Router,
+            DHCPOption.IPAddressLeaseTime,
+            DHCPOption.ServerIdentifier,
+            DHCPOption.RenewalTimeValue,
+            DHCPOption.RebindingTimeValue,
+        ])
+    ]
+
+    if requested_ip:
+        if isinstance(requested_ip, ipaddress.IPv4Address):
+            requested_ip = requested_ip.packed
+        common.append((DHCPOption.RequestedIPAddress, requested_ip))
+
+    return common
+
+
+class DHCP4(object):
     def __init__(self, iface):
         self.iface = iface
-        self.yiaddr = None
+        self.sock = DHCP4Socket(iface.ifname)
 
-        self.sock = DHCP4Socket(self.iface.ifname)
-        self.poll = select.poll()
-        self.poll.register(self.sock, select.POLLIN | select.POLLPRI)
-
+        self._yiaddr = None
+        self._subnet_mask = None
         self._ready_event = threading.Event()
         self._stop_event = threading.Event()
         self._thread = threading.Thread(target=self._lease)
@@ -38,44 +173,45 @@ class DHCP(object):
 
         logger.info('Setting {} on {}...'.format(self.yiaddr,
                                                  self.iface.ifname))
-        self.iface.add_ip(self.yiaddr, mask=self.subnet_mask)
+        self.iface.add_ip(self.yiaddr.compressed,
+                          mask=self.subnet_mask.compressed)
         self.iface.commit()
 
-    def close(self):
-        self._stop_event.set()
-        self._send(dhcp.BOOTREQUEST,
-                   {'message_type': dhcp.DHCPRELEASE,
-                    'requested_ip': self.yiaddr,
-                    'server_id': self.server_id,
-                    'parameter_list': DHCP_PARAMS})
+    def _discover(self, src=None):
+        logger.info('Sending DHCP4 discover on {}...'.format(self.iface.ifname))
+        chaddr = src or self.sock.src
+        options = build_options(DHCPMessage.Discover, chaddr)
+        packet = DHCPPacket(DHCPOpCode.Request, chaddr=chaddr, options=options)
+        return self.sock.send(packet, src=src, expect=DHCPMessage.Offer)
+
+    def _request(self, yiaddr, src=None):
+        logger.info('Sending DHCP4 request on {}...'.format(self.iface.ifname))
+        chaddr = src or self.sock.src
+        options = build_options(DHCPMessage.Request, chaddr, requested_ip=yiaddr)
+        packet = DHCPPacket(DHCPOpCode.Request, chaddr=chaddr, options=options)
+        return self.sock.send(packet, src=src, expect=DHCPMessage.ACK)
+
+    def _release(self, yiaddr, src=None):
+        logger.info('Sending DHCP4 release on {}...'.format(self.iface.ifname))
+        chaddr = src or self.sock.src
+        options = build_options(DHCPMessage.Release, chaddr, requested_ip=yiaddr)
+        packet = DHCPPacket(DHCPOpCode.Request, chaddr=chaddr, options=options)
+        self.sock.send(packet, src=src)
 
     def _lease(self):
-        logger.info('Sending DHCPDISCOVER on {}...'.format(self.iface.ifname))
-        reply = self._send(dhcp.BOOTREQUEST,
-                           {'message_type': dhcp.DHCPDISCOVER,
-                            'parameter_list': DHCP_PARAMS},
-                           expect=dhcp.DHCPOFFER)
-
-        self.server_id = reply['options']['server_id']
-        self.yiaddr = reply['yiaddr']
+        offer = self._discover()
+        self._yiaddr = offer.yiaddr
 
         while True:
-            logger.info('Sending DHCPREQUEST on {}...'
-                        .format(self.iface.ifname))
+            reply = self._request(self._yiaddr)
+            options = dict(reply.options)
 
-            reply = self._send(dhcp.BOOTREQUEST,
-                               {'message_type': dhcp.DHCPREQUEST,
-                                'requested_ip': self.yiaddr,
-                                'server_id': self.server_id,
-                                'parameter_list': DHCP_PARAMS},
-                               expect=dhcp.DHCPACK)
-
-            self.server_id = reply['options']['server_id']
-            self.yiaddr = reply['yiaddr']
-            self.subnet_mask = reply['options']['subnet_mask']
-
+            self._yiaddr = reply.yiaddr
+            self._subnet_mask = options[DHCPOption.SubnetMask].tobytes()
             self._ready_event.set()
-            lease_time = reply['secs']
+
+            # TODO: fix
+            lease_time = reply.secs
 
             # If there's either no leasetime, or the stop event has
             # been set before our renew timeout, renew our lease
@@ -86,30 +222,14 @@ class DHCP(object):
                 logger.debug('Leaving DHCP renewal loop!')
                 return
 
-    def _send(self, op, options, expect=None, timeout=2):
-        msg = dhcp4msg({
-            'op': op,
-            'chaddr': self.sock.l2addr,
-            'options': options
-        })
+    def close(self):
+        self._stop_event.set()
+        self._release(self._yiaddr)
 
-        if not expect:
-            self.sock.put(msg)
-            return
+    @property
+    def yiaddr(self):
+        return ipaddress.IPv4Address(self._yiaddr)
 
-        start = time.time()
-        while time.time() - start <= timeout:
-            xid = self.sock.put(msg)['xid']
-
-            for fd, _ in self.poll.poll(timeout):
-                assert fd == self.sock.fileno()
-
-                response = self.sock.get()
-                if response['xid'] != xid:
-                    continue
-                if response['options']['message_type'] != expect:
-                    raise RuntimeError('DHCP protocol error')
-                return response
-            time.sleep(0.5)
-        else:
-            raise RuntimeError('Failed to acquire dhcp lease')
+    @property
+    def subnet_mask(self):
+        return ipaddress.IPv4Address(self._subnet_mask)

--- a/lab/network/macvlan.py
+++ b/lab/network/macvlan.py
@@ -11,7 +11,7 @@ import logging
 import socket
 import ipaddress
 import pyroute2
-from .dhcp import DHCP
+from .dhcp import DHCP4
 
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ class MacVLan(object):
         # Start dhcp process if necessary
         if dhcp:
             try:
-                self.dhcp = DHCP(vlan)
+                self.dhcp = DHCP4(vlan)
             except RuntimeError:
                 self.close()
                 raise

--- a/pnet/__init__.py
+++ b/pnet/__init__.py
@@ -111,6 +111,16 @@ class ethhdr(msg):
               ('type', 'be16'))
 
 
+class sllhdr(msg):
+    min_size = 16
+    fields = (('pkttype', 'be16'),
+              ('hatype', 'be16'),
+              ('halen', 'be16'),
+              ('src', 'l2addr'),
+              ('pad', 'be16'),
+              ('type', 'be16'))
+
+
 class ip4hdr(msg):
     min_size = 20
     fields = (('verlen', 'uint8', 0x45),

--- a/pnet/__init__.py
+++ b/pnet/__init__.py
@@ -1,7 +1,7 @@
 import struct
 import ipaddress
 from .utils import HWAddress
-from .msg import ParseError, msg, csum
+from .msg import ParseError, msg, checksum
 
 
 # IEEE = 802.3 Ethernet magic constants. The frame sizes omit the
@@ -95,7 +95,7 @@ def ipv4_checksum(ip4, udp, data):
     ip4_dst = ip4['dst']
     ip4_len = len(data) + udphdr.min_size
 
-    return csum(
+    return checksum(
         ip4_src.packed if ip4_src else b'\x00' * 4,
         ip4_dst.packed if ip4_dst else b'\x00' * 4,
         struct.pack('!HH', ip4['proto'], ip4_len),
@@ -123,12 +123,6 @@ class ip4hdr(msg):
               ('csum', 'be16'),
               ('src', 'ip4addr'),
               ('dst', 'ip4addr'))
-
-    def __getitem__(self, key):
-        # TODO: cleanup, this shouldn't be treated as special
-        if key == 'csum':
-            return csum(self.tobytes())
-        return msg.__getitem__(self, key)
 
 
 class udphdr(msg):

--- a/pnet/__init__.py
+++ b/pnet/__init__.py
@@ -1,7 +1,7 @@
 import struct
 import ipaddress
 from .utils import HWAddress
-from .msg import msg, csum
+from .msg import ParseError, msg, csum
 
 
 # IEEE = 802.3 Ethernet magic constants. The frame sizes omit the

--- a/pnet/__init__.py
+++ b/pnet/__init__.py
@@ -1,0 +1,139 @@
+import struct
+import ipaddress
+from .utils import HWAddress
+from .msg import msg, csum
+
+
+# IEEE = 802.3 Ethernet magic constants. The frame sizes omit the
+# preamble and FCS/CRC (frame check sequence).
+ETH_ALEN = 6  # Octets in one ethernet addr
+ETH_HLEN = 14  # Total octets in header.
+ETH_ZLEN = 60  # Min. octets in frame sans FCS
+ETH_DATA_LEN = 1500  # Max. octets in payload
+ETH_FRAME_LEN = 1514  # Max. octets in frame sans FCS
+ETH_FCS_LEN = 4  # Octets in the FCS
+
+# These are the defined Ethernet Protocol ID's.
+ETH_P_LOOP = 0x0060  # Ethernet Loopback packet
+ETH_P_PUP = 0x0200  # Xerox PUP packet
+ETH_P_PUPAT = 0x0201  # Xerox PUP Addr Trans packet
+ETH_P_IP = 0x0800  # Internet Protocol packet
+ETH_P_X25 = 0x0805  # CCITT X.25
+ETH_P_ARP = 0x0806  # Address Resolution packet
+ETH_P_BPQ = 0x08FF  # G8BPQ AX.25 Ethernet Packet
+ETH_P_IEEEPUP = 0x0a00  # Xerox IEEE802.3 PUP packet
+ETH_P_IEEEPUPAT = 0x0a01  # Xerox IEEE802.3 PUP Addr Trans packet
+ETH_P_DEC = 0x6000  # DEC Assigned proto
+ETH_P_DNA_DL = 0x6001  # DEC DNA Dump/Load
+ETH_P_DNA_RC = 0x6002  # DEC DNA Remote Console
+ETH_P_DNA_RT = 0x6003  # DEC DNA Routing
+ETH_P_LAT = 0x6004  # DEC LAT
+ETH_P_DIAG = 0x6005  # DEC Diagnostics
+ETH_P_CUST = 0x6006  # DEC Customer use
+ETH_P_SCA = 0x6007  # DEC Systems Comms Arch
+ETH_P_TEB = 0x6558  # Trans Ether Bridging
+ETH_P_RARP = 0x8035  # Reverse Addr Res packet
+ETH_P_ATALK = 0x809B  # Appletalk DDP
+ETH_P_AARP = 0x80F3  # Appletalk AARP
+ETH_P_8021Q = 0x8100  # = 802.1Q VLAN Extended Header
+ETH_P_IPX = 0x8137  # IPX over DIX
+ETH_P_IPV6 = 0x86DD  # IPv6 over bluebook
+ETH_P_PAUSE = 0x8808  # IEEE Pause frames. See = 802.3 = 31B
+ETH_P_SLOW = 0x8809  # Slow Protocol. See = 802.3ad = 43B
+ETH_P_WCCP = 0x883E  # Web-cache coordination protocol
+ETH_P_PPP_DISC = 0x8863  # PPPoE discovery messages
+ETH_P_PPP_SES = 0x8864  # PPPoE session messages
+ETH_P_MPLS_UC = 0x8847  # MPLS Unicast traffic
+ETH_P_MPLS_MC = 0x8848  # MPLS Multicast traffic
+ETH_P_ATMMPOA = 0x884c  # MultiProtocol Over ATM
+ETH_P_LINK_CTL = 0x886c  # HPNA, wlan link local tunnel
+ETH_P_ATMFATE = 0x8884  # Frame-based ATM Transport over Ethernet
+ETH_P_PAE = 0x888E  # Port Access Entity (IEEE = 802.1X)
+ETH_P_AOE = 0x88A2  # ATA over Ethernet
+ETH_P_8021AD = 0x88A8  # = 802.1ad Service VLAN
+ETH_P_802_EX1 = 0x88B5  # = 802.1 Local Experimental = 1.
+ETH_P_TIPC = 0x88CA  # TIPC
+ETH_P_8021AH = 0x88E7  # = 802.1ah Backbone Service Tag
+ETH_P_1588 = 0x88F7  # IEEE = 1588 Timesync
+ETH_P_FCOE = 0x8906  # Fibre Channel over Ethernet
+ETH_P_TDLS = 0x890D  # TDLS
+ETH_P_FIP = 0x8914  # FCoE Initialization Protocol
+ETH_P_QINQ1 = 0x9100  # deprecated QinQ VLAN
+ETH_P_QINQ2 = 0x9200  # deprecated QinQ VLAN
+ETH_P_QINQ3 = 0x9300  # deprecated QinQ VLAN
+ETH_P_EDSA = 0xDADA  # Ethertype DSA
+ETH_P_AF_IUCV = 0xFBFB  # IBM af_iucv
+
+# Non DIX types. Won't clash for = 1500 types.
+ETH_P_802_3 = 0x0001  # Dummy type for = 802.3 frames
+ETH_P_AX25 = 0x0002  # Dummy protocol id for AX.25
+ETH_P_ALL = 0x0003  # Every packet (be careful!!!)
+ETH_P_802_2 = 0x0004  # = 802.2 frames
+ETH_P_SNAP = 0x0005  # Internal only
+ETH_P_DDCMP = 0x0006  # DEC DDCMP: Internal only
+ETH_P_WAN_PPP = 0x0007  # Dummy type for WAN PPP frames*/
+ETH_P_PPP_MP = 0x0008  # Dummy type for PPP MP frames
+ETH_P_LOCALTALK = 0x0009  # Localtalk pseudo type
+ETH_P_CAN = 0x000C  # Controller Area Network
+ETH_P_PPPTALK = 0x0010  # Dummy type for Atalk over PPP*/
+ETH_P_TR_802_2 = 0x0011  # = 802.2 frames
+ETH_P_MOBITEX = 0x0015  # Mobitex (kaz@cafe.net)
+ETH_P_CONTROL = 0x0016  # Card specific control frames
+ETH_P_IRDA = 0x0017  # Linux-IrDA
+ETH_P_ECONET = 0x0018  # Acorn Econet
+ETH_P_HDLC = 0x0019  # HDLC frames
+ETH_P_ARCNET = 0x001A  # = 1A for ArcNet :-)
+ETH_P_DSA = 0x001B  # Distributed Switch Arch.
+ETH_P_TRAILER = 0x001C  # Trailer switch tagging
+ETH_P_PHONET = 0x00F5  # Nokia Phonet frames
+ETH_P_IEEE802154 = 0x00F6  # IEEE802.15.4 frame
+ETH_P_CAIF = 0x00F7  # ST-Ericsson CAIF protocol
+
+
+def ipv4_checksum(ip4, udp, data):
+    ip4_src = ip4['src']
+    ip4_dst = ip4['dst']
+    ip4_len = len(data) + udphdr.min_size
+
+    return csum(
+        ip4_src.packed if ip4_src else b'\x00' * 4,
+        ip4_dst.packed if ip4_dst else b'\x00' * 4,
+        struct.pack('!HH', ip4['proto'], ip4_len),
+        udp.tobytes(),
+        data
+    )
+
+
+class ethhdr(msg):
+    min_size = 14
+    fields = (('dst', 'l2addr'),
+              ('src', 'l2addr'),
+              ('type', 'be16'))
+
+
+class ip4hdr(msg):
+    min_size = 20
+    fields = (('verlen', 'uint8', 0x45),
+              ('dsf', 'uint8'),
+              ('len', 'be16'),
+              ('id', 'be16'),
+              ('flags', 'uint16'),
+              ('ttl', 'uint8', 128),
+              ('proto', 'uint8'),
+              ('csum', 'be16'),
+              ('src', 'ip4addr'),
+              ('dst', 'ip4addr'))
+
+    def __getitem__(self, key):
+        # TODO: cleanup, this shouldn't be treated as special
+        if key == 'csum':
+            return csum(self.tobytes())
+        return msg.__getitem__(self, key)
+
+
+class udphdr(msg):
+    min_size = 8
+    fields = (('sport', 'be16'),
+              ('dport', 'be16'),
+              ('len', 'be16'),
+              ('csum', 'be16'))

--- a/pnet/bpf.py
+++ b/pnet/bpf.py
@@ -1,0 +1,77 @@
+import struct
+import ctypes
+import socket
+import enum
+
+
+SO_ATTACH_FILTER = 26
+
+
+class Op(enum.IntEnum):
+    # Instruction classes
+    LD = 0x00
+    LDX = 0x01
+    ST = 0x02
+    STX = 0x03
+    ALU = 0x04
+    JMP = 0x05
+    RET = 0x06
+    MISC = 0x07
+    # ld/ldx fields
+    W = 0x00
+    H = 0x08
+    B = 0x10
+    IMM = 0x00
+    ABS = 0x20
+    IND = 0x40
+    MEM = 0x60
+    LEN = 0x80
+    MSH = 0xa0
+    # alu/jmp fields */
+    ADD = 0x00
+    SUB = 0x10
+    MUL = 0x20
+    DIV = 0x30
+    OR = 0x40
+    AND = 0x50
+    LSH = 0x60
+    RSH = 0x70
+    NEG = 0x80
+    MOD = 0x90
+    XOR = 0xa0
+    JA = 0x00
+    JEQ = 0x10
+    JGT = 0x20
+    JGE = 0x30
+    JSET = 0x40
+    K = 0x00
+    X = 0x08
+
+
+def bpf_jump(ops, k, jt, jf):
+    code = 0
+    for op in ops:
+        code |= op.value
+    return struct.pack('HBBI', code, jt, jf, k)
+
+
+def bpf_stmt(ops, k):
+    return bpf_jump(ops, k, 0, 0)
+
+
+class bpf(list):
+    def tobytes(self):
+        return b''.join(self)
+
+    def __bytes__(self):
+        return self.tobytes()
+
+    def compile(self):
+        buf = ctypes.create_string_buffer(self.tobytes())
+        return struct.pack('HL', len(self), ctypes.addressof(buf)), buf
+
+
+def attach_filter(sock, bpf):
+    bpf_repr, program = bpf.compile()
+    sock.setsockopt(socket.SOL_SOCKET, SO_ATTACH_FILTER, bpf_repr)
+    return program

--- a/pnet/dhcp4/__init__.py
+++ b/pnet/dhcp4/__init__.py
@@ -1,0 +1,147 @@
+import os
+import struct
+import socket
+import enum
+import pnet
+from binascii import unhexlify
+from pnet.bpf import bpf, bpf_stmt, bpf_jump, Op
+from .options import DHCPOption, Options
+
+
+COOKIE = b'c\x82Sc'  # [0x63, 0x82, 0x53, 0x63])
+
+
+class DHCPOpCode(enum.IntEnum):
+    Request = 1
+    Reply = 2
+
+
+class DHCPMessage(enum.IntEnum):
+    Discover = 1
+    Offer = 2
+    Request = 3
+    Decline = 4
+    ACK = 5
+    NAK = 6
+    Release = 7
+    Inform = 8
+
+
+class DHCPPacket:
+    layout = struct.Struct('!BBBB4s2s2s4s4s4s4s6s202x')
+
+    def __init__(self, opcode, buf=None, **kwargs):
+        self.opcode = opcode
+        self.htype = 1  # Ethernet
+        self.hops = 0
+        self.xid = kwargs.get('xid')
+        self.secs = kwargs.get('secs', b'\x00' * 2)
+        self.flags = kwargs.get('flags', b'\x00' * 2)
+        self.ciaddr = kwargs.get('ciaddr', b'\x00' * 4)
+        self.yiaddr = kwargs.get('yiaddr', b'\x00' * 4)
+        self.siaddr = kwargs.get('siaddr', b'\x00' * 4)
+        self.giaddr = kwargs.get('giaddr', b'\x00' * 4)
+        self.chaddr = pnet.HWAddress(kwargs['chaddr'])
+        self.options = Options(kwargs.get('options', []))
+        if not self.xid:
+            self.xid = os.urandom(4)
+
+    @classmethod
+    def parse(cls, payload):
+        _, _, options = payload.tobytes().partition(COOKIE)
+        assert options  # TODO: improve error reporting
+
+        result = cls.layout.unpack_from(payload)
+        self = cls(
+            result[0],
+            xid=result[4],
+            secs=result[5],
+            flags=result[6],
+            ciaddr=result[7],
+            yiaddr=result[8],
+            siaddr=result[9],
+            giaddr=result[10],
+            chaddr=result[11],
+            options=Options.parse(memoryview(options))
+        )
+
+        self.htype = result[1]
+        self.hops = result[3]
+        return self
+
+    def tobytes(self):
+        chaddr = self.chaddr.packed
+        header = self.layout.pack(
+            self.opcode,  # 0
+            self.htype,  # 1
+            len(chaddr),  # 2
+            self.hops,  # 3
+            self.xid,  # 4:8
+            self.secs,  # 8:10
+            self.flags,  # 10:12
+            self.ciaddr,  # 12:16
+            self.yiaddr,  # 16:20
+            self.siaddr,  # 20:24
+            self.giaddr,  # 24:28
+            chaddr  # 28:44
+        )
+        payload = b''.join((header, COOKIE, self.options.tobytes()))
+        return payload.ljust(272, b'\x00')
+
+    def __bytes__(self):
+        return self.tobytes()
+
+
+def get_vendor_info():
+    sysname, _, release, _, machine = os.uname()
+    return b'pydhcp4:{}-{}:{}'.format(sysname, release, machine)
+
+
+def discover(chaddr=None, hostname=None, vendor=None):
+    if not hostname:
+        hostname = socket.gethostname()
+    if not vendor:
+        vendor = get_vendor_info()
+
+    options = [
+        (DHCPOption.DHCPMessageType, [DHCPMessage.Discover]),
+        (DHCPOption.ClientIdentifier, [
+            0xff, 0xb9, 0xcc, 0x05, 0x1a, 0x00, 0x01, 0x1d,
+            0x49, 0x20, 0x30, 0x00, 0x50, 0xb6, 0x13, 0x48,
+            0xef
+        ]),
+        (DHCPOption.MaximumDHCPMessageSize, [0x05, 0xc0]),
+        (DHCPOption.VendorClassIdentifier, vendor.encode('ascii')),
+        (DHCPOption.HostName, hostname.encode('ascii')),
+        (DHCPOption.ParameterRequestList, [
+            0x01, 0x79, 0x21, 0x03, 0x06, 0x0c, 0x0f, 0x1a,
+            0x1c, 0x2a, 0x33, 0x36, 0x3a, 0x3b, 0x77
+        ])
+    ]
+
+    return DHCPPacket(DHCPOpCode.Request,
+                      chaddr=chaddr.packed,
+                      options=options)
+
+
+def bootp_filter(port=68):
+    return bpf([
+        # Check the udp port number
+        bpf_stmt([Op.LD, Op.H, Op.ABS], 0x24),
+        bpf_jump([Op.JMP, Op.JEQ, Op.K], port, 0, 7),
+
+        # Check ip fragment offset is 0 to verify TCP
+        bpf_stmt([Op.LD, Op.H, Op.ABS], 0x14),
+        bpf_jump([Op.JMP, Op.JSET, Op.K], 0x1fff, 5, 0),
+
+        # Check tcp protocol field
+        bpf_stmt([Op.LD, Op.B, Op.ABS], 0x17),
+        bpf_jump([Op.JMP, Op.JEQ, Op.K], socket.IPPROTO_UDP, 0, 3),
+
+        # Check ethertype field for IPv4
+        bpf_stmt([Op.LD, Op.H, Op.ABS], 0x0c),
+        bpf_jump([Op.JMP, Op.JEQ, Op.K], pnet.ETH_P_IP, 0, 1),
+
+        bpf_stmt([Op.RET, Op.K], 0xffffffff),
+        bpf_stmt([Op.RET, Op.K], 0),
+    ])

--- a/pnet/dhcp4/__init__.py
+++ b/pnet/dhcp4/__init__.py
@@ -28,15 +28,15 @@ class DHCPMessage(enum.IntEnum):
 
 
 class DHCPPacket:
-    layout = struct.Struct('!BBBB4s2s2s4s4s4s4s6s202x')
+    layout = struct.Struct('!BBBB4sHH4s4s4s4s6s202x')
 
     def __init__(self, opcode, buf=None, **kwargs):
         self.opcode = opcode
         self.htype = 1  # Ethernet
         self.hops = 0
         self.xid = kwargs.get('xid')
-        self.secs = kwargs.get('secs', b'\x00' * 2)
-        self.flags = kwargs.get('flags', b'\x00' * 2)
+        self.secs = kwargs.get('secs', 0)
+        self.flags = kwargs.get('flags', 0)
         self.ciaddr = kwargs.get('ciaddr', b'\x00' * 4)
         self.yiaddr = kwargs.get('yiaddr', b'\x00' * 4)
         self.siaddr = kwargs.get('siaddr', b'\x00' * 4)
@@ -49,9 +49,14 @@ class DHCPPacket:
     @classmethod
     def parse(cls, payload):
         _, _, options = payload.tobytes().partition(COOKIE)
-        assert options  # TODO: improve error reporting
+        if not options:
+            raise pnet.ParseError('Failed to find DHCP cookie')
 
-        result = cls.layout.unpack_from(payload)
+        try:
+            result = cls.layout.unpack_from(payload)
+        except struct.error as e:
+            raise ParseError(str(e))
+
         self = cls(
             result[0],
             xid=result[4],
@@ -91,37 +96,20 @@ class DHCPPacket:
     def __bytes__(self):
         return self.tobytes()
 
+    @property
+    def message_type(self):
+        options = dict(self.options)
+        payload = options[DHCPOption.DHCPMessageType].tobytes()
+        return DHCPMessage(ord(payload[0]))
+
 
 def get_vendor_info():
     sysname, _, release, _, machine = os.uname()
     return b'pydhcp4:{}-{}:{}'.format(sysname, release, machine)
 
 
-def discover(chaddr=None, hostname=None, vendor=None):
-    if not hostname:
-        hostname = socket.gethostname()
-    if not vendor:
-        vendor = get_vendor_info()
-
-    options = [
-        (DHCPOption.DHCPMessageType, [DHCPMessage.Discover]),
-        (DHCPOption.ClientIdentifier, [
-            0xff, 0xb9, 0xcc, 0x05, 0x1a, 0x00, 0x01, 0x1d,
-            0x49, 0x20, 0x30, 0x00, 0x50, 0xb6, 0x13, 0x48,
-            0xef
-        ]),
-        (DHCPOption.MaximumDHCPMessageSize, [0x05, 0xc0]),
-        (DHCPOption.VendorClassIdentifier, vendor.encode('ascii')),
-        (DHCPOption.HostName, hostname.encode('ascii')),
-        (DHCPOption.ParameterRequestList, [
-            0x01, 0x79, 0x21, 0x03, 0x06, 0x0c, 0x0f, 0x1a,
-            0x1c, 0x2a, 0x33, 0x36, 0x3a, 0x3b, 0x77
-        ])
-    ]
-
-    return DHCPPacket(DHCPOpCode.Request,
-                      chaddr=chaddr.packed,
-                      options=options)
+def get_client_id(chaddr):
+    return struct.pack('!B6s', 1, chaddr.packed)
 
 
 def bootp_filter(port=68):

--- a/pnet/dhcp4/options.py
+++ b/pnet/dhcp4/options.py
@@ -1,0 +1,119 @@
+import enum
+
+
+class DHCPOption(enum.IntEnum):
+    Padding = 0
+    SubnetMask = 1
+    TimeOffset = 2
+    Router = 3
+    TimeServer = 4
+    NameServer = 5
+    DomainNameServer = 6
+    LogServer = 7
+    CookieServer = 8
+    LPRServer = 9
+    ImpressServer = 10
+    ResourceLocationServer = 11
+    HostName = 12
+    BootFileSize = 13
+    MeritDumpFile = 14
+    DomainName = 15
+    SwapServer = 16
+    RootPath = 17
+    ExtensionsPath = 18
+    IPForwardingEnableDisable = 19
+    NonLocalSourceRoutingEnableDisable = 20
+    PolicyFilter = 21
+    MaximumDatagramReassemblySize = 22
+    DefaultIPTimeToLive = 23
+    PathMTUAgingTimeout = 24
+    PathMTUPlateauTable = 25
+    InterfaceMTU = 26
+    AllSubnetsAreLocal = 27
+    BroadcastAddress = 28
+    PerformMaskDiscovery = 29
+    MaskSupplier = 30
+    PerformRouterDiscovery = 31
+    RouterSolicitationAddress = 32
+    StaticRoute = 33
+    TrailerEncapsulation = 34
+    ARPCacheTimeout = 35
+    EthernetEncapsulation = 36
+    TCPDefaultTTL = 37
+    TCPKeepaliveInterval = 38
+    TCPKeepaliveGarbage = 39
+    NetworkInformationServiceDomain = 40
+    NetworkInformationServers = 41
+    NetworkTimeProtocolServers = 42
+    VendorSpecificInformation = 43
+    NetBIOSOverTCPIPNameServer = 44
+    NetBIOSOverTCPIPDatagramDistributionServer = 45
+    NetBIOSOverTCPIPNodeType = 46
+    NetBIOSOverTCPIPScope = 47
+    XWindowSystemFontServer = 48
+    XWindowSystemDisplayManager = 49
+    RequestedIPAddress = 50
+    IPAddressLeaseTime = 51
+    Overload = 52
+    DHCPMessageType = 53
+    ServerIdentifier = 54
+    ParameterRequestList = 55
+    Message = 56
+    MaximumDHCPMessageSize = 57
+    RenewalTimeValue = 58
+    RebindingTimeValue = 59
+    VendorClassIdentifier = 60
+    ClientIdentifier = 61
+    NetworkInformationServicePlusDomain = 64
+    NetworkInformationServicePlusServers = 65
+    TFTPServerName = 66
+    BootFileName = 67
+    MobileIPHomeAgent = 68
+    SimpleMailTransportProtocol = 69
+    PostOfficeProtocolServer = 70
+    NetworkNewsTransportProtocol = 71
+    DefaultWorldWideWebServer = 72
+    DefaultFingerServer = 73
+    DefaultInternetRelayChatServer = 74
+    StreetTalkServer = 75
+    StreetTalkDirectoryAssistance = 76
+    UserClass = 77
+    RelayAgentInformation = 82
+    ClientArchitecture = 93
+    TZPOSIXString = 100
+    TZDatabaseString = 101
+    DomainSearchOptionFormat = 119
+    ClasslessRouteFormat = 121
+    End = 255
+
+
+class Options(list):
+    def __bytes__(self):
+        return self.tobytes()
+
+    def tobytes(self):
+        options = bytearray()
+
+        for op, payload in self:
+            options.extend([op, len(payload)])
+            options.extend(payload)
+
+        options.append(DHCPOption.End)
+        return bytes(options)
+
+    @classmethod
+    def parse(cls, payload):
+        orig_payload = payload
+        options = []
+
+        while payload:
+            op = DHCPOption(ord(payload[0]))
+            if op == DHCPOption.End:
+                break
+
+            length = ord(payload[1])
+            contents = payload[2:length+2]
+            options.append((op, contents))
+            payload = payload[length+2:]
+
+        return cls(options)

--- a/pnet/msg.py
+++ b/pnet/msg.py
@@ -1,0 +1,127 @@
+import struct
+from ipaddress import IPv4Address
+from .utils import HWAddress
+
+
+TYPES = {
+    'uint8': 'B',
+    'uint16': 'H',
+    'be16': '>H',
+    'ip4addr': {
+        'format': '4s',
+        'decode': IPv4Address,
+        'encode': lambda addr: addr.packed
+    },
+    'l2addr': {
+        'format': '6s',
+        'decode': HWAddress,
+        'encode': lambda addr: addr.packed
+    }
+}
+
+
+def csum(*data):
+    # TODO: Use iterator to avoid copying
+    data = b''.join(data)
+
+    if len(data) % 2:
+        data += b'\x00'
+
+    csum = sum(struct.unpack('!H', data[x:x+2])[0]
+               for x in range(0, len(data), 2))
+
+    csum = (csum >> 16) + (csum & 0xffff)
+    csum += csum >> 16
+    return ~csum & 0xffff
+
+
+class msg(dict):
+    buf = None
+    fields = ()
+    _fields_names = ()
+
+    def __init__(self, content=None, offset=0, buf=None):
+        content = content or {}
+        dict.__init__(self, content)
+        self._register_fields()
+        self.offset = offset
+        # NOTE: we assume this is zeroed
+        self.buf = memoryview(buf or bytearray(0x100))
+        if content and not self.buf.readonly:
+            self._encode()
+
+    @classmethod
+    def parse(cls, buf, offset=0):
+        self = cls(buf=buf, offset=offset)
+        self._decode()
+        return self
+
+    def _register_fields(self):
+        self._fields_names = tuple([x[0] for x in self.fields])
+
+    def _get_routine(self, mode, fmt):
+        fmt = TYPES.get(fmt, fmt)
+        if isinstance(fmt, dict):
+            return (fmt['format'], fmt.get(mode, lambda x: x))
+        else:
+            return (fmt, lambda x: x)
+
+    def _decode(self):
+        self.offset = 0
+        for field in self.fields:
+            name, sfmt = field[:2]
+            fmt, routine = self._get_routine('decode', sfmt)
+            size = struct.calcsize(fmt)
+            value = struct.unpack_from(fmt, self.buf, self.offset)
+            if len(value) == 1:
+                value = value[0]
+            self[name] = routine(value)
+            self.offset += size
+
+    def _encode(self):
+        self.offset = 0
+        for field in self.fields:
+            name, fmt = field[:2]
+            default = b'\x00' if len(field) <= 2 else field[2]
+            fmt, routine = self._get_routine('encode', fmt)
+
+            size = struct.calcsize(fmt)
+            if self[name] is None:
+                # Assume we have an empty buffer
+                if not isinstance(default, bytes):
+                    struct.pack_into(fmt, self.buf, self.offset, default)
+            else:
+                value = routine(self[name])
+                if not isinstance(value, (set, tuple, list)):
+                    value = [value]
+                struct.pack_into(fmt, self.buf, self.offset, *value)
+
+            self.offset += size
+
+    def __getitem__(self, key):
+        try:
+            return dict.__getitem__(self, key)
+        except KeyError:
+            if key in self._fields_names:
+                return None
+            raise
+
+    def __setitem__(self, key, value):
+        dict.__setitem__(self, key, value)
+        # TODO: smell...
+        if not self.buf.readonly:
+            self._encode()
+
+    def tobytes(self):
+        return self.buf[:self.offset].tobytes()
+
+    def __bytes__(self):
+        return self.tobytes()
+
+    @property
+    def payload(self):
+        return self.buf[self.offset:]
+
+    @payload.setter
+    def payload(self, data):
+        self.buf[self.offset:] = data

--- a/pnet/msg.py
+++ b/pnet/msg.py
@@ -3,6 +3,10 @@ from ipaddress import IPv4Address
 from .utils import HWAddress
 
 
+class ParseError(RuntimeError):
+    """Failed to unpack structure."""
+
+
 TYPES = {
     'uint8': 'B',
     'uint16': 'H',
@@ -53,7 +57,10 @@ class msg(dict):
     @classmethod
     def parse(cls, buf, offset=0):
         self = cls(buf=buf, offset=offset)
-        self._decode()
+        try:
+            self._decode()
+        except struct.error as e:
+            raise ParseError(str(e))
         return self
 
     def _register_fields(self):

--- a/pnet/utils.py
+++ b/pnet/utils.py
@@ -1,0 +1,24 @@
+from binascii import unhexlify
+
+
+class HWAddress(object):
+    """Represent and manipulate MAC addresses."""
+    def __init__(self, address):
+        """
+        Args:
+            address: A string or integer representing the MAC
+        """
+
+        if isinstance(address, bytes) and len(address) == 6:
+            self.packed = address
+        elif isinstance(address, HWAddress):
+            self.packed = address.packed
+        else:
+            self.packed = unhexlify(address.replace(':', ''))
+            assert len(self.packed) == 6
+
+    def __str__(self):
+        return ':'.join([format(ord(x), 'x') for x in self.packed])
+
+    def __repr__(self):
+        return "HWAddress('{}')".format(self)


### PR DESCRIPTION
There are still **lots** of room for improvement in this, but its a good functional start and we need the client replaced sooner than later, as its occasionally failing in production.

### What this will fix

The problem was in the existing half-hazard raw socket re-transmission/waiting logic. When network gets a little congested and the best case doesn't happen, the old logic was actually contributing to the mess and sending out more dhcp re-transmission packets at a very high rate. The new raw socket implementation here has been crafted very carefully to be much more reliable and retransmit slowly.

It also seemed like the old raw socket implementation has a flawed blf program attached to it that was causing it to try to parse some non-BOOTP packets, but not correct enough smartly handle parsing failures.

### What else do we get

The pnet library here is really promising. As I polish it up and publish it standalone, it should be able to also improve our media analysis code. It still needs some work, but its looking promising to be a more efficient and flexible core than dpkt.

### What's left to do

More consistency between `ip4hdr` and friends and `DHCPPacket`, cleaner encode/decode core, add ipv6.